### PR TITLE
patch bug for hindcasting

### DIFF
--- a/R/portalcast.R
+++ b/R/portalcast.R
@@ -157,6 +157,9 @@ prep_data <- function(options_data = data_options()){
   if (metadata$forecast_date != today()){
     fill_data(options_data)
   }
+  if (options_data$cast_type == "hindcasts"){
+    fill_data(options_data)
+  }
 }
 
 #' @title Multiple forecast or hindcast


### PR DESCRIPTION
hindcasting from a not-setup-for-hindcasting (i.e. setup for forecasting) directory was breaking because the metadata in particular was not updating. now, the first cast in the series of casts fills the data directory with the hindcast versions in case they weren't there
(i.e. to address #14) 