### PR TITLE
model_options function documentation and testing

### DIFF
--- a/R/model_options.R
+++ b/R/model_options.R
@@ -1,91 +1,128 @@
 #' @title Prepare options for a portalcasting model
 #'
 #' @description Suite of functions used to generate model-writing options 
-#'   lists: \cr \cr \code{model_options} is a basic template. Not to be 
-#'   confused with \code{\link{models_options}}, which creates the options 
-#'   list for the \code{models} subdirectory
+#'   lists: \cr \cr \code{model_options} is a basic template that provides
+#'   validation of all of the inputs (specific models' functions can thus just 
+#'   wrap around this generalized function). Not to be confused with 
+#'   \code{\link{models_options}}, which creates the options list for the 
+#'   \code{models} subdirectory.
 #'
-#' @param tree directory tree
+#' @param tree \code{dirtree}-class directory tree list. See 
+#'   \code{\link{dirtree}}.
 #'
-#' @param name character name of the model (MUST match the function name)
+#' @param name \code{character}-valued name of the model (MUST match the 
+#'   function name).
 #'
-#' @param covariates does the model require covariates
+#' @param covariates \code{logical} indicator for if the model requires 
+#'   covariates.
 #'
-#' @param lag lag time used for the covariates (\code{NULL} if 
-#'   \code{covariates} is false)
+#' @param lag \code{numeric} integer lag time used for the covariates 
+#'   or \code{NULL} if \code{covariates} is \code{FALSE}.
 #'
-#' @param quiet logical indicator if progress messages should be quieted
+#' @param quiet \code{logical} indicator controlling if messages are printed.
 #'
-#' @return \code{model_options}: a list of model options
+#' @return \code{model_options}: a class-\code{model_options} \code{list} of 
+#'   options used to set up a general model script. 
 #'
 #' @export
 #'
 model_options <- function(tree = dirtree(), name = "AutoArima", 
                           covariates = FALSE, lag = NULL, quiet = FALSE){
+  if (!("dirtree" %in% class(tree))){
+    stop("`tree` is not of class dirtree")
+  }
+  if (!is.character(name )){
+    stop("`name` is not a character")
+  }
+  if (length(name) > 1){
+    stop("`name` can only be of length = 1")
+  }
+  if (!("logical" %in% class(covariates))){
+    stop("`covariates` is not of class logical")
+  }
+  if (!("logical" %in% class(quiet))){
+    stop("`quiet` is not of class logical")
+  }
+  if (length(lag) > 1){
+    stop("`lag` can only be of length = 1")
+  }
+  if (!is.null(lag)){
+    if (!("numeric" %in% class(lag)) & !("integer" %in% class(lag))){
+      stop("`lag` is not of class numeric or integer")
+    }
+    if(lag < 0 | lag %% 1 != 0){
+      stop("`lag` is not a non-negative integer")
+    }
+  }
   list(name = name, covariates = covariates, lag = lag, quiet = quiet, 
-       tree = tree)
+       tree = tree) %>%
+  classy(c("model_options", "list"))
 }
 
 #' @rdname model_options
 #'
-#' @description \code{AutoArima_options} creates a list of control options for
-#'   the AutoArima model 
+#' @description \code{AutoArima_options} creates a \code{model_options} 
+#'   \code{list} of control options for the model script controlling the 
+#'   \code{\link{AutoArima}} model.
 #'
-#' @return \code{AutoArima_options}: a list of settings controlling the 
-#'   AutoArima model creation
+#' @return \code{AutoArima_options}: a \code{model_options} \code{list} of 
+#'   settings controlling the \code{\link{AutoArima}} model creation.
 #'
 #' @export
 #'
 AutoArima_options <- function(tree = dirtree(), name = "AutoArima", 
                               covariates = FALSE, lag = NULL, quiet = FALSE){
-  list(name = name, covariates = covariates, lag = lag, quiet = quiet, 
-       tree = tree)
+  model_options(tree = tree, name = name, covariates = covariates, lag = lag, 
+                quiet = quiet) 
 }
 
 #' @rdname model_options
 #'
-#' @description \code{ESSS_options} creates a list of control options for
-#'   the ESSS model 
+#' @description \code{ESSS_options} creates a \code{model_options} 
+#'   \code{list} of control options for the model script controlling the 
+#'   \code{\link{ESSS}} model.
 #'
-#' @return \code{ESSS_options}: a list of settings controlling the 
-#'   ESSS model creation
+#' @return \code{ESSS_options}: a \code{model_options} \code{list} of 
+#'   settings controlling the \code{\link{ESSS}} model creation.
 #'
 #' @export
 #'
 ESSS_options <- function(tree = dirtree(),  name = "ESSS", covariates = FALSE, 
                          lag = NULL, quiet = FALSE){
-  list(name = name, covariates = covariates, lag = lag, quiet = quiet, 
-       tree = tree)
+  model_options(tree = tree, name = name, covariates = covariates, lag = lag, 
+                quiet = quiet) 
 }
 
 #' @rdname model_options
 #'
-#' @description \code{nbGARCH_options} creates a list of control options for
-#'   the nbGARCH model 
+#' @description \code{nbGARCH_options} creates a \code{model_options} 
+#'   \code{list} of control options for the model script controlling the 
+#'   \code{\link{nbGARCH}} model.
 #'
-#' @return \code{nbGARCH_options}: a list of settings controlling the 
-#'   nbGARCH model creation
+#' @return \code{nbGARCH_options}: a \code{model_options} \code{list} of 
+#'   settings controlling the \code{\link{nbGARCH}} model creation.
 #'
 #' @export
 #'
 nbGARCH_options <- function(tree = dirtree(), name = "nbGARCH", 
                             covariates = FALSE, lag = NULL, quiet = FALSE){
-  list(name = name, covariates = covariates, lag = lag, quiet = quiet, 
-       tree = tree)
+  model_options(tree = tree, name = name, covariates = covariates, lag = lag, 
+                quiet = quiet) 
 }
 
 #' @rdname model_options
 #'
-#' @description \code{pevGARCH_options} creates a list of control options for
-#'   the pevGARCH model 
+#' @description \code{pevGARCH_options} creates a \code{model_options} 
+#'   \code{list} of control options for the model script controlling the 
+#'   \code{\link{pevGARCH}} model.
 #'
-#' @return \code{pevGARCH_options}: a list of settings controlling the 
-#'   pevGARCH model creation
+#' @return \code{pevGARCH_options}: a \code{model_options} \code{list} of 
+#'   settings controlling the \code{\link{pevGARCH}} model creation.
 #'
 #' @export
 #'
 pevGARCH_options <- function(tree = dirtree(), name = "pevGARCH", 
                              covariates = TRUE, lag = 6, quiet = FALSE){
-  list(name = name, covariates = covariates, lag = lag, quiet = quiet, 
-       tree = tree)
+  model_options(tree = tree, name = name, covariates = covariates, lag = lag, 
+                quiet = quiet) 
 }

--- a/man/model_options.Rd
+++ b/man/model_options.Rd
@@ -24,47 +24,57 @@ pevGARCH_options(tree = dirtree(), name = "pevGARCH",
   covariates = TRUE, lag = 6, quiet = FALSE)
 }
 \arguments{
-\item{tree}{directory tree}
+\item{tree}{\code{dirtree}-class directory tree list. See 
+\code{\link{dirtree}}.}
 
-\item{name}{character name of the model (MUST match the function name)}
+\item{name}{\code{character}-valued name of the model (MUST match the 
+function name).}
 
-\item{covariates}{does the model require covariates}
+\item{covariates}{\code{logical} indicator for if the model requires 
+covariates.}
 
-\item{lag}{lag time used for the covariates (\code{NULL} if 
-\code{covariates} is false)}
+\item{lag}{\code{numeric} integer lag time used for the covariates 
+or \code{NULL} if \code{covariates} is \code{FALSE}.}
 
-\item{quiet}{logical indicator if progress messages should be quieted}
+\item{quiet}{\code{logical} indicator controlling if messages are printed.}
 }
 \value{
-\code{model_options}: a list of model options
+\code{model_options}: a class-\code{model_options} \code{list} of 
+  options used to set up a general model script.
 
-\code{AutoArima_options}: a list of settings controlling the 
-  AutoArima model creation
+\code{AutoArima_options}: a \code{model_options} \code{list} of 
+  settings controlling the \code{\link{AutoArima}} model creation.
 
-\code{ESSS_options}: a list of settings controlling the 
-  ESSS model creation
+\code{ESSS_options}: a \code{model_options} \code{list} of 
+  settings controlling the \code{\link{ESSS}} model creation.
 
-\code{nbGARCH_options}: a list of settings controlling the 
-  nbGARCH model creation
+\code{nbGARCH_options}: a \code{model_options} \code{list} of 
+  settings controlling the \code{\link{nbGARCH}} model creation.
 
-\code{pevGARCH_options}: a list of settings controlling the 
-  pevGARCH model creation
+\code{pevGARCH_options}: a \code{model_options} \code{list} of 
+  settings controlling the \code{\link{pevGARCH}} model creation.
 }
 \description{
 Suite of functions used to generate model-writing options 
-  lists: \cr \cr \code{model_options} is a basic template. Not to be 
-  confused with \code{\link{models_options}}, which creates the options 
-  list for the \code{models} subdirectory
+  lists: \cr \cr \code{model_options} is a basic template that provides
+  validation of all of the inputs (specific models' functions can thus just 
+  wrap around this generalized function). Not to be confused with 
+  \code{\link{models_options}}, which creates the options list for the 
+  \code{models} subdirectory.
 
-\code{AutoArima_options} creates a list of control options for
-  the AutoArima model
+\code{AutoArima_options} creates a \code{model_options} 
+  \code{list} of control options for the model script controlling the 
+  \code{\link{AutoArima}} model.
 
-\code{ESSS_options} creates a list of control options for
-  the ESSS model
+\code{ESSS_options} creates a \code{model_options} 
+  \code{list} of control options for the model script controlling the 
+  \code{\link{ESSS}} model.
 
-\code{nbGARCH_options} creates a list of control options for
-  the nbGARCH model
+\code{nbGARCH_options} creates a \code{model_options} 
+  \code{list} of control options for the model script controlling the 
+  \code{\link{nbGARCH}} model.
 
-\code{pevGARCH_options} creates a list of control options for
-  the pevGARCH model
+\code{pevGARCH_options} creates a \code{model_options} 
+  \code{list} of control options for the model script controlling the 
+  \code{\link{pevGARCH}} model.
 }

--- a/tests/testthat/test-06-model_options.R
+++ b/tests/testthat/test-06-model_options.R
@@ -1,1 +1,41 @@
 context("Test model_options functions")
+
+
+test_that("model_options", {
+  expect_error(model_options(tree = 1, name = "AutoArima", 
+                             covariates = FALSE, lag = NULL, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = 1, 
+                             covariates = FALSE, lag = NULL, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = c("AutoArima", "ESSS"), 
+                             covariates = FALSE, lag = NULL, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = "AutoArima", 
+                             covariates = 1, lag = NULL, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = "AutoArima", 
+                             covariates = FALSE, lag = -1, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = "AutoArima", 
+                             covariates = FALSE, lag = 2.2, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = "AutoArima", 
+                             covariates = FALSE, lag = 1:2, quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = "AutoArima", 
+                             covariates = FALSE, lag = NULL, quiet = 1))
+
+  opts <- model_options(tree = dirtree(), name = "AutoArima", 
+                        covariates = FALSE, lag = NULL, quiet = FALSE)
+  expect_is(opts, "model_options")
+})
+
+test_that("AutoArima_options", {
+  expect_is(AutoArima_options(), "model_options")
+})
+
+test_that("ESSS_options", {
+  expect_is(ESSS_options(), "model_options")
+})
+
+test_that("nbGARCH_options", {
+  expect_is(nbGARCH_options(), "model_options")
+})
+
+test_that("pevGARCH_options", {
+  expect_is(pevGARCH_options(), "model_options")
+})

--- a/tests/testthat/test-06-model_options.R
+++ b/tests/testthat/test-06-model_options.R
@@ -15,6 +15,8 @@ test_that("model_options", {
   expect_error(model_options(tree = dirtree(), name = "AutoArima", 
                              covariates = FALSE, lag = 2.2, quiet = FALSE))
   expect_error(model_options(tree = dirtree(), name = "AutoArima", 
+                             covariates = FALSE, lag = "a", quiet = FALSE))
+  expect_error(model_options(tree = dirtree(), name = "AutoArima", 
                              covariates = FALSE, lag = 1:2, quiet = FALSE))
   expect_error(model_options(tree = dirtree(), name = "AutoArima", 
                              covariates = FALSE, lag = NULL, quiet = 1))


### PR DESCRIPTION
define the model_options class, enforce input types in model_options,  wrap the specific model option functions around model_options to tidy checks and enforecement