### PR TITLE
Update prepare_models.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,11 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
-# [portalcasting 0.4.1](https://github.com/weecology/portalcasting)
+# [portalcasting 0.4.2](https://github.com/weecology/portalcasting)
 *active development* 
+
+# [portalcasting 0.4.1](https://github.com/weecology/portalcasting/releases/tag/v0.4.1)
+*2019-03-19*
 
 ### Move to usage of CRAN *portalr*
 * To aid with stability, we're now using the [CRAN release of portalr](https://cran.r-project.org/package=portalr)
@@ -17,6 +20,11 @@ loaded in top level functions.
 
 ### Vignette updates
 * Adding plot (from pre-constructed images) to the how-to vignette.
+
+### Patching a bug in `model_template`
+* There was a lingering old name from the argument switch over that was
+causing model templates to be written with a `""` argument for the `model`
+model name input into `save_forecast_output`.
 
 # [portalcasting 0.4.0](https://github.com/weecology/portalcasting/releases/tag/v0.4.0)
 *2019-03-16* 

--- a/R/prepare_models.R
+++ b/R/prepare_models.R
@@ -115,7 +115,7 @@ model_template <- function(options_model = model_options()){
 f_a <- ', name ,'(', args_a, ');
 f_c <- ', name ,'(', args_c, ');
 save_forecast_output(f_a, f_c, "', 
-options_model$name, '", tree)'
+options_model$model, '", tree)'
 )
 
 }


### PR DESCRIPTION
patching `model_template` which still had an old usage of the `name` component that's been replaced with `model`