### PR TITLE
fix edge case in nbGARCH and nbsGARCH

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalcasting
 Title: Functions used in predicting Portal rodent dynamics
-Version: 0.6.0
+Version: 0.7.0
 Authors@R: c(
   person(c("Juniper", "L."), "Simonis", email = "juniper.simonis@weecology.org", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9798-0460")),
   person(c("Glenda", "M."), "Yenni", role = c("aut"), comment = c(ORCID = "0000-0001-6969-1848")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+# [portalcasting 0.7.0](https://github.com/weecology/portalcasting/releases/tag/v0.7.0)
+*2019-03-21*
+
+### Addressing `nbGARCH` and `nbsGARCH` when even the Poisson fallback fails
+* In `nbGARCH` and then extended into `nbsGARCH`, the models fall back
+to a Poisson distribution if the negative binomial fit fails. Previously
+(with only `nbGARCH`) the Poisson fit always succeeded in those back-ups,
+but now (with `nbsGARCH`) that sometimes isn't the case (because the predictor
+model is more complex) and even the Poisson fit can fail. So now for both 
+models, if that fit fails, we follow what occurs in `pevGARCH` which is to
+use the `fcast0` forecast of 0s and an arbitrarily high AIC (`1e6`).
+
 # [portalcasting 0.6.0](https://github.com/weecology/portalcasting/releases/tag/v0.6.0)
 *2019-03-20*
 

--- a/R/nbGARCH.R
+++ b/R/nbGARCH.R
@@ -58,12 +58,18 @@ nbGARCH <- function(tree = dirtree(), level = "All", quiet = FALSE){
                  tsglm(abund_s, model = past, distr = "nbinom", link = "log"),
                  warning = function(x){NULL}, error = function(x){NULL})
       if(is.null(model) || AIC(model) == Inf){
-          model <- tsglm(abund_s, 
-                     model = past,
-                     distr = "poisson", link = "log")
+          model <- tryCatch(
+                     tsglm(abund_s, model = past,
+                           distr = "poisson", link = "log"),
+                     warning = function(x){NULL}, error = function(x){NULL})
       }
-      model_fcast <- predict(model, nfcnm, level = CL)
-      model_aic <- AIC(model)
+      if(is.null(model) || AIC(model) == Inf){
+        model_fcast <- fcast0(nfcnm)
+        model_aic <- 1e6
+      } else {
+        model_fcast <- predict(model, nfcnm, level = CL)
+        model_aic <- AIC(model)
+      }
     }    
 
     estimate <- as.numeric(model_fcast$pred)

--- a/R/nbsGARCH.R
+++ b/R/nbsGARCH.R
@@ -77,13 +77,19 @@ nbsGARCH <- function(tree = dirtree(), level = "All", quiet = FALSE){
                        xreg = predictors, link = "log"),
                  warning = function(x){NULL}, error = function(x){NULL})
       if(is.null(model) || AIC(model) == Inf){
-          model <- tsglm(abund_s, 
-                     model = past,
-                     distr = "poisson", xreg = predictors, link = "log")
+          model <- tryCatch(
+                     tsglm(abund_s, model = past, distr = "poisson", 
+                           xreg = predictors, link = "log"),
+                     warning = function(x){NULL}, error = function(x){NULL})
       }
-      model_fcast <- predict(model, nfcnm, level = CL, 
-                             newxreg = fcast_predictors)
-      model_aic <- AIC(model)
+      if(is.null(model) || AIC(model) == Inf){
+        model_fcast <- fcast0(nfcnm)
+        model_aic <- 1e6
+      } else {
+        model_fcast <- predict(model, nfcnm, level = CL, 
+                              newxreg = fcast_predictors)
+        model_aic <- AIC(model)
+      }
     }    
 
     estimate <- as.numeric(model_fcast$pred)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ image update (*i.e.* the integration of the current master branch of
 repository](https://github.com/weecology/portalPredictions)) necessarily
 lags behind updates to the master branch of `portalcasting`, although
 ideally not long behind. The `latest` image is built using `portalcasting` 
-[v0.6.0](https://github.com/weecology/portalcasting/releases/tag/v0.6.0).
+[v0.7.0](https://github.com/weecology/portalcasting/releases/tag/v0.7.0).
 
-The API is moderately well defined at this point, but is still somewhat evolving.
+The API is moderately well defined at this point, but is still evolving.
 
 ## Installation
 


### PR DESCRIPTION
In `nbGARCH` and then extended into `nbsGARCH`, the models fall back to a Poisson distribution if the negative binomial fit fails. Previously (with only `nbGARCH`) the Poisson fit always succeeded in those back-ups, but now (with `nbsGARCH`) that sometimes isn't the case (because the predictor model is more complex) and even the Poisson fit can fail. So now for both  models, if that fit fails, we follow what occurs in `pevGARCH` which is to use the `fcast0` forecast of 0s and an arbitrarily high AIC (`1e6`).