### PR TITLE
Use RStudio package manager in GH Actions

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/bionic/latest
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1
@@ -27,8 +28,8 @@ jobs:
           sudo apt-get install jags
       - name: Install package dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck"))
-          remotes::install_deps(dependencies = TRUE)
+          install.packages(c("remotes", "rcmdcheck"), repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
+          remotes::install_deps(dependencies = TRUE, repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
         shell: Rscript {0}
       - name: Check
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,9 +11,10 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/bionic/latest
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +24,7 @@ jobs:
 
       - name: Query dependencies
         run: |
-          install.packages('remotes')
+          install.packages('remotes', repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
@@ -42,9 +43,10 @@ jobs:
           sudo apt-get install gsl-bin libgsl0-dev
           sudo apt-get install libcurl4-openssl-dev
           sudo apt-get install jags
+
       - name: Install package dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
           remotes::install_github("tidyverse/tidytemplate")
           remotes::install_dev("pkgdown")
         shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/bionic/latest
     steps:
       - uses: actions/checkout@v2
 
@@ -22,7 +23,7 @@ jobs:
 
       - name: Query dependencies
         run: |
-          install.packages('remotes')
+          install.packages('remotes', repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
@@ -43,9 +44,9 @@ jobs:
           sudo apt-get install jags
       - name: Install package dependencies
         run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
+          install.packages(c("remotes"), repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
+          remotes::install_deps(dependencies = TRUE, repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
+          remotes::install_cran("covr", repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
         shell: Rscript {0}
 
       - name: Test coverage

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalcasting
 Title: Functions Used in Predicting Portal Rodent Dynamics
-Version: 0.21.1
+Version: 0.21.2
 Authors@R: c(
     person(c("Juniper", "L."), "Simonis",
       email = "juniper.simonis@weecology.org", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+portalcasting 0.21.2
+*In Progress*
+
+### Improving GitHub Actions Running 
+* Including no running of examples (needed to be explicitly stated); [addressing 206](https://github.com/weecology/portalcasting/issues/206)
+* Use RStudio package manager to speed up running; [addressing 206](https://github.com/weecology/portalcasting/issues/206)
+
+
 [portalcasting 0.21.1](https://github.com/weecology/portalcasting/releases/tag/v0.21.1)
 *2021-02-11*
 


### PR DESCRIPTION
This speeds up the package installation by about 15 minutes by using
RStudio Package manager binaries for Ubuntu.

Motivated by #206 (but not a full solution).