### PR TITLE
Speed up pkgdown build by not building examples

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -57,4 +57,4 @@ jobs:
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE, examples = FALSE)'


### PR DESCRIPTION
The examples for this package are very slow due to the need to run
`setup_dir()` repeatedly and the fact that several of the examples
related to fitting and making forecasts are inherently computationally
intensive.

This change stops the running of examples when building the docs
website, which reduces build time from several hours to a few
minutes and allows the site to be deployed properly via CI.

Fixes #206