### PR TITLE
Run all actions on Ubuntu 20.04 with matching RStudio repo

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -12,10 +12,10 @@ name: R-CMD-check-release
 
 jobs:
   R-CMD-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/bionic/latest
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/focal/latest
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,10 +11,10 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/bionic/latest
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/focal/latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -10,10 +10,10 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/bionic/latest
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/focal/latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
GitHub Actions recently upgraded ubuntu-latest to 20.04 from 18.04.
The RStudio package manager was setup for 18.04, which was hardcoded in one action but not the others.
This change hardcodes all runs onto 20.04 and updates the RStudio package manager repos to match.

Fixes #209.