### PR TITLE
patching issue with ndvi preparation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalcasting
 Title: Functions Used in Predicting Portal Rodent Dynamics
-Version: 0.22.0
+Version: 0.23.0
 Authors@R: c(
     person(c("Juniper", "L."), "Simonis",
       email = "juniper.simonis@weecology.org", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+
+# [portalcasting 0.23.0](https://github.com/weecology/portalcasting/releases/tag/v0.23.0)
+*2021-11-10*
+
+### patching issue with ndvi preparation
+* the ndvi data stream is not filling in with new content, resulting in NAs for the latter half of 2021
+* using a forecast call to fill in the missing values as a temporary patch 
+
+
 # [portalcasting 0.22.0](https://github.com/weecology/portalcasting/releases/tag/v0.22.0)
 *2021-11-09*
 

--- a/R/prepare_covariates.R
+++ b/R/prepare_covariates.R
@@ -190,6 +190,25 @@ prep_hist_covariates <- function(main = ".", moons = NULL,
   out <- out[ , colnames(out) %in% cols_in]
   out <- summarize_daily_weather_by_moon(out)
   out$source <- "hist"
+
+#
+# patching NDVI 
+#
+
+  na_ndvi <- is.na(out$ndvi)
+
+  if (na_ndvi[nrow(out)]) {
+
+    last_good <- max(which(!na_ndvi))
+    full_length <- nrow(out)
+    window_length <- full_length - last_good
+
+    ndvi_fit <- auto.arima(out$ndvi)
+    ndvi_cast <- forecast(ndvi_fit, h = window_length)
+    out$ndvi[(last_good + 1):full_length] <- as.numeric(ndvi_cast$mean)
+
+  }
+
   data.frame(out)
 }
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ over from the [predictions repository](https://github.com/weecology/portalPredic
 We leverage a [software container](https://en.wikipedia.org/wiki/Operating-system-level_virtualization) to enable reproducibility of the [predictions repository](https://github.com/weecology/portalPredictions). Presently, we use a [Docker](https://hub.docker.com/r/weecology/portalcasting) image of the software environment to create a container for running the code. The image is automatically rebuilt when there is a new `portalcasting` release, tagged with both the `latest` and version-specific (`vX.X.X`) tags, and pushed to [DockerHub](https://hub.docker.com/r/weecology/portalcasting). 
 
 
-Because the `latest` image is updated with releases, the current master branch code in `portalcasting` is not necessarily always being executed within the [predictions repository](https://github.com/weecology/portalPredictions). Rather, the most recent release is what is currently being executed. Presently, the `latest` image is built using `portalcasting` [v0.22.0](https://github.com/weecology/portalcasting/releases/tag/v0.22.0).
+Because the `latest` image is updated with releases, the current master branch code in `portalcasting` is not necessarily always being executed within the [predictions repository](https://github.com/weecology/portalPredictions). Rather, the most recent release is what is currently being executed. Presently, the `latest` image is built using `portalcasting` [v0.23.0](https://github.com/weecology/portalcasting/releases/tag/v0.23.0).
 
 A development image (`dev`) is built from the master branch of `portalcasting` at every push to facilitate testing and should not be considered stable.
 

--- a/notes.R
+++ b/notes.R
@@ -6,6 +6,22 @@
 
 devtools::document()
 devtools::load_all()
+
+
+main <- "./testing"
+setup_production(main)
+portalcast(main)
+
+plot_cast_ts(main = main, data_set = "controls")
+plot_cast_point(main = main, data_set = "controls")
+most_ab <- most_abundant_species(main = main, data_set = "controls")
+for(i in 1:3){
+  plot_cast_ts(main = main, data_set = "controls", species = most_ab[i])
+}
+plot_casts_err_lead(main = main)
+plot_casts_cov_RMSE(main = main)
+
+
 devtools::build()
 devtools::test()
 


### PR DESCRIPTION
the ndvi data stream is not filling in with new content, resulting in NAs for the latter half of 2021
using a forecast call to fill in the missing values as a temporary patch

addresses #224 