### PR TITLE
Check that package builds before pushing docker container

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,8 +22,38 @@ env:
 
 
 jobs:
-  build:
+  
+  R-CMD-check:
+    # Copy of the R-CMD-check workflow to make sure that build passes before pushing container on new tag
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CRAN_REPO: https://packagemanager.rstudio.com/all/__linux__/focal/latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v1
+      
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install texlive-latex-base libharfbuzz-dev libfribidi-dev
+          sudo apt-get install gsl-bin libgsl0-dev
+          sudo apt-get install libcurl4-openssl-dev
+          sudo apt-get install jags
+      - name: Install package dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"), repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
+          remotes::install_deps(dependencies = TRUE, repos = c("CRAN" = Sys.getenv("CRAN_REPO")))
+        shell: Rscript {0}
+      - name: Check
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}
 
+  build:
+    needs: R-CMD-check
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Runs a copy of the R-CMD-check workflow before building the docker image
checks to make sure it passed before continuing. This prevents a tag
from resulting in a bad image being pushed.

Co-authored-by: Henry Senyondo <henrykironde@gmail.com>