### PR TITLE
Update NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
-# portalcasting 0.41.0
-*In Progress*
+# [portalcasting 0.41.0](https://github.com/weecology/portalcasting/releases/tag/v0.41.0)
+*2022-05-26*
 
 
 ### Data interpolation moved from "dataset" to "within model"


### PR DESCRIPTION
### Data interpolation moved from "dataset" to "within model"
* Previously, datasets included, for example `all` and `all_interp`. Now, only `all` exists and models interpolate as needed.
