### PR TITLE
trim text in model vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalcasting
 Title: Functions Used in Predicting Portal Rodent Dynamics
-Version: 0.42.0
+Version: 0.43.0
 Authors@R: c(
     person(c("Juniper", "L."), "Simonis",
       email = "juniper.simonis@weecology.org", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
 Suggests:
   knitr,
   pkgdown,
+  english,
   markdown,
   rmarkdown,
   testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+# [portalcasting 0.43.0](https://github.com/weecology/portalcasting/releases/tag/v0.43.0)
+*2022-05-31*
+
+
+### Trim text in model vignette
+* Vignette now pulls text from the the model list, and loops the model list, rather than have the raw text in the markdown doc.
+* This locates the description in a place that is accessible to other content generation (e.g., the portal forecast website)
+
 # [portalcasting 0.42.0](https://github.com/weecology/portalcasting/releases/tag/v0.42.0)
 *2022-05-27*
 

--- a/R/prefab_models.R
+++ b/R/prefab_models.R
@@ -178,9 +178,10 @@ AutoArima <- function (main     = ".",
     cast_tab <- rbind(cast_tab, cast_tab_s)
   }
 
-  metadata <- update_list(metadata, models           = "AutoArima",
-                                    datasets         = dataset,
-                                    dataset_controls = dataset_controls)
+  metadata <- update_list(metadata, 
+                          models           = "AutoArima",
+                          datasets         = dataset,
+                          dataset_controls = dataset_controls)
 
   list(metadata    = metadata, 
        cast_tab    = cast_tab, 

--- a/R/prepare_models.R
+++ b/R/prepare_models.R
@@ -34,8 +34,19 @@ model_controls <- function (main     = ".",
                             models   = prefab_models(),
                             settings = directory_settings()) {
 
-  read_model_controls(main     = main, 
-                      settings = settings)[[models]]
+  nmodels <- length(models)
+
+  if (nmodels == 1) {
+
+    read_model_controls(main     = main, 
+                        settings = settings)[[models]]
+
+  } else if (nmodels > 1) {
+
+    read_model_controls(main     = main, 
+                        settings = settings)[models]
+
+  }
 
 }
 

--- a/R/prepare_models.R
+++ b/R/prepare_models.R
@@ -35,7 +35,7 @@ model_controls <- function (main     = ".",
                             settings = directory_settings()) {
 
   read_model_controls(main     = main, 
-                      settings = settings)[models]
+                      settings = settings)[[models]]
 
 }
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,7 +19,7 @@ navbar:
        - text: "portalcasting codebase"
          href: articles/codebase.html
     reference: 
-      text: "Functions"
+      text: "Reference"
       href: reference/index.html
     news: 
       text: "News"

--- a/code_development/model_shell.R
+++ b/code_development/model_shell.R
@@ -1,0 +1,275 @@
+model_shell <- function (main     = ".", 
+                         model = NULL,
+                       dataset  = "all",
+                       settings = directory_settings(), 
+                       quiet    = FALSE, 
+                       verbose  = FALSE) {
+
+  return_if_null(model)
+
+  controls <- model_controls(main = main, 
+                 models = model,
+                 settings = settings)
+
+  dataset <- tolower(dataset)
+
+  messageq("  -", controls$metadata$name, " for ", dataset, quiet = quiet)
+
+  rodents_table <- read_rodents_table(main     = main, 
+                                      dataset  = dataset,
+                                      settings = settings)
+  species       <- species_from_table(rodents_tab = rodents_table, 
+                                      total       = TRUE, 
+                                      nadot       = TRUE)
+  nspecies      <- length(species)
+
+  metadata <- read_metadata(main     = main,
+                            settings = settings)
+
+  start_moon       <- metadata$time$start_moon
+  end_moon         <- metadata$time$end_moon
+
+  cast_moons       <- metadata$time$rodent_cast_moons
+
+  confidence_level <- metadata$confidence_level
+  dataset_controls <- metadata$dataset_controls[[dataset]]
+
+  moon_in          <- rodents_table$newmoonnumber >= start_moon & rodents_table$newmoonnumber <= end_moon
+  rodents_table    <- rodents_table[moon_in, ]
+  nmoons           <- length(cast_moons)
+  mods             <- named_null_list(species)
+  casts            <- named_null_list(species)
+  cast_tab         <- data.frame()
+
+  for (i in 1:nspecies) {
+
+    s  <- species[i]
+    ss <- gsub("NA.", "NA", s)
+
+    messageq("   -", ss, quiet = !verbose)
+
+    abund_s <- rodents_table[ , s]
+
+    if (sum(abund_s, na.rm = TRUE) == 0) {
+      next()
+    }
+
+    mods[[i]]  <- auto.arima(abund_s)
+    casts[[i]] <- forecast(mods[[i]], h = nmoons, level = confidence_level)
+    casts[[i]] <- data.frame(casts[[i]], moon = cast_moons)
+
+    cast_tab_s <- data.frame(cast_date        = metadata$time$cast_date, 
+                             cast_month       = metadata$time$rodent_cast_months,
+                             cast_year        = metadata$time$rodent_cast_years, 
+                             moon             = metadata$time$rodent_cast_moons,
+                             currency         = dataset_controls$args$output,
+                             model            = "AutoArima", 
+                             dataset          = dataset, 
+                             species          = ss, 
+                             cast_group       = metadata$cast_group,
+                             confidence_level = metadata$confidence_level,
+                             estimate         = casts[[i]][ , "Point.Forecast"], 
+                             lower_pi         = casts[[i]][ , paste0("Lo.", confidence_level * 100)], 
+                             upper_pi         = casts[[i]][ , paste0("Hi.", confidence_level * 100)], 
+                             start_moon       = metadata$time$start_moon,
+                             end_moon         = metadata$time$end_moon)
+
+    cast_tab <- rbind(cast_tab, cast_tab_s)
+  }
+
+  metadata <- update_list(metadata, 
+                          models           = "AutoArima",
+                          datasets         = dataset,
+                          dataset_controls = dataset_controls)
+
+  list(metadata    = metadata, 
+       cast_tab    = cast_tab, 
+       model_fits  = mods, 
+       model_casts = casts)
+
+}
+
+
+
+
+
+#' @rdname prefab_model_functions
+#'
+#' @export
+#'
+
+NaiveArima <- function (main     = ".", 
+                        dataset  = "all",
+                        settings = directory_settings(), 
+                        quiet    = FALSE, 
+                        verbose  = FALSE) {
+
+  dataset <- tolower(dataset)
+
+  messageq("  -NaiveArima for ", dataset, quiet = quiet)
+
+  rodents_table <- read_rodents_table(main     = main, 
+                                      dataset  = dataset,
+                                      settings = settings)
+  species       <- species_from_table(rodents_tab = rodents_table, 
+                                      total       = TRUE, 
+                                      nadot       = TRUE)
+  nspecies      <- length(species)
+
+  metadata <- read_metadata(main     = main,
+                            settings = settings)
+
+  start_moon       <- metadata$time$start_moon
+  end_moon         <- metadata$time$end_moon
+
+  cast_moons       <- metadata$time$rodent_cast_moons
+
+  confidence_level <- metadata$confidence_level
+  dataset_controls <- metadata$dataset_controls[[dataset]]
+
+  moon_in          <- rodents_table$newmoonnumber >= start_moon & rodents_table$newmoonnumber <= end_moon
+  rodents_table    <- rodents_table[moon_in, ]
+  nmoons           <- length(cast_moons)
+  mods             <- named_null_list(species)
+  casts            <- named_null_list(species)
+  cast_tab         <- data.frame()
+
+  for (i in 1:nspecies) {
+
+    s  <- species[i]
+    ss <- gsub("NA.", "NA", s)
+
+    messageq("   -", ss, quiet = !verbose)
+
+    abund_s <- rodents_table[ , s]
+
+    if (sum(abund_s, na.rm = TRUE) == 0) {
+      next()
+    }
+
+    mods[[i]]  <- Arima(abund_s, order = c(0, 1, 0))
+    casts[[i]] <- forecast(mods[[i]], h = nmoons, level = confidence_level)
+    casts[[i]] <- data.frame(casts[[i]], moon = cast_moons)
+
+    cast_tab_s <- data.frame(cast_date        = metadata$time$cast_date, 
+                             cast_month       = metadata$time$rodent_cast_months,
+                             cast_year        = metadata$time$rodent_cast_years, 
+                             moon             = metadata$time$rodent_cast_moons,
+                             currency         = dataset_controls$args$output,
+                             model            = "NaiveArima", 
+                             dataset          = dataset, 
+                             species          = ss, 
+                             cast_group       = metadata$cast_group,
+                             confidence_level = metadata$confidence_level,
+                             estimate         = casts[[i]][ ,"Point.Forecast"], 
+                             lower_pi         = casts[[i]][ ,paste0("Lo.", confidence_level * 100)], 
+                             upper_pi         = casts[[i]][ ,paste0("Hi.", confidence_level * 100)], 
+                             start_moon       = metadata$time$start_moon,
+                             end_moon         = metadata$time$end_moon)
+
+    cast_tab <- rbind(cast_tab, cast_tab_s)
+  }
+
+  metadata <- update_list(metadata, models           = "NaiveArima",
+                                    datasets         = dataset,
+                                    dataset_controls = dataset_controls)
+
+  list(metadata    = metadata, 
+       cast_tab    = cast_tab, 
+       model_fits  = mods, 
+       model_casts = casts)
+
+}
+
+
+
+
+
+#' @rdname prefab_model_functions
+#' 
+#' @export
+#'
+
+ESSS <- function (main     = ".", 
+                  dataset  = "all",
+                  settings = directory_settings(), 
+                  quiet    = FALSE, 
+                  verbose  = FALSE) {
+
+  dataset <- tolower(dataset)
+
+  messageq("  -ESSS for ", dataset, quiet = quiet)
+
+  rodents_table <- read_rodents_table(main     = main, 
+                                      dataset  = dataset,
+                                      settings = settings)
+  species       <- species_from_table(rodents_tab = rodents_table, 
+                                      total       = TRUE, 
+                                      nadot       = TRUE)
+  nspecies      <- length(species)
+
+  metadata <- read_metadata(main     = main,
+                            settings = settings)
+
+  start_moon       <- metadata$time$start_moon
+  end_moon         <- metadata$time$end_moon
+
+  cast_moons       <- metadata$time$rodent_cast_moons
+
+  confidence_level <- metadata$confidence_level
+  dataset_controls <- metadata$dataset_controls[[dataset]]
+
+  moon_in          <- rodents_table$newmoonnumber >= start_moon & rodents_table$newmoonnumber <= end_moon
+  rodents_table    <- rodents_table[moon_in, ]
+  nmoons           <- length(cast_moons)
+  mods             <- named_null_list(species)
+  casts            <- named_null_list(species)
+  cast_tab         <- data.frame()
+
+  for (i in 1:nspecies) {
+
+    s  <- species[i]
+    ss <- gsub("NA.", "NA", s)
+
+    messageq("   -", ss, quiet = !verbose)
+
+    abund_s <- round(na.interp(rodents_table[ , s]))
+
+    if (sum(abund_s, na.rm = TRUE) == 0) {
+      next()
+    }
+
+    mods[[i]]  <- ets(abund_s)
+    casts[[i]] <- forecast(mods[[i]], h = nmoons, level = confidence_level,
+                           allow.multiplicative.trend = TRUE)
+    casts[[i]] <- data.frame(casts[[i]], moon = cast_moons)
+
+    cast_tab_s <- data.frame(cast_date        = metadata$time$cast_date, 
+                             cast_month       = metadata$time$rodent_cast_months,
+                             cast_year        = metadata$time$rodent_cast_years, 
+                             moon             = metadata$time$rodent_cast_moons,
+                             currency         = dataset_controls$args$output,
+                             model            = "ESSS", 
+                             cast_group       = metadata$cast_group,
+                             confidence_level = metadata$confidence_level,
+                             dataset          = dataset, 
+                             species          = ss, 
+                             estimate         = casts[[i]][ , "Point.Forecast"], 
+                             lower_pi         = casts[[i]][ , paste0("Lo.", confidence_level * 100)], 
+                             upper_pi         = casts[[i]][ , paste0("Hi.", confidence_level * 100)], 
+                             start_moon       = metadata$time$start_moon,
+                             end_moon         = metadata$time$end_moon)
+
+    cast_tab <- rbind(cast_tab, cast_tab_s)
+  }
+
+  metadata <- update_list(metadata, models           = "ESSS",
+                                    datasets         = dataset,
+                                    dataset_controls = dataset_controls)
+
+  list(metadata    = metadata, 
+       cast_tab    = cast_tab, 
+       model_fits  = mods, 
+       model_casts = casts)
+
+}

--- a/code_development/notes.R
+++ b/code_development/notes.R
@@ -8,7 +8,7 @@ main <- "~/portalcasting"
 
 setup_production(main = main)
 
-
+# working in "model shell"
 
 
 

--- a/inst/extdata/prefab_dataset_controls.yaml
+++ b/inst/extdata/prefab_dataset_controls.yaml
@@ -2,6 +2,7 @@ all:
   metadata:
     name: all
     descriptor: classic dataset, all plots combined
+    text: Twenty focal species and total abundance summed across all plots at the newmoon.
   fun: prep_dataset
   args:
     name: all
@@ -46,6 +47,7 @@ controls:
   metadata:
     name: controls
     descriptor: classic dataset, control plots combined
+    text: Twenty focal species and total abundance summed across control plots at the newmoon.
   fun: prep_dataset
   args:
     name: controls
@@ -90,6 +92,7 @@ exclosures:
   metadata:
     name: exclosures
     descriptor: classic dataset, exclosure plots combined
+    text: Twenty focal species and total abundance summed across exclosure plots at the newmoon.
   fun: prep_dataset
   args:
     name: exclosures
@@ -134,6 +137,7 @@ dm_controls:
   metadata:
     name: dm_controls
     descriptor: DM only, control plots combined
+    text: Dipodomys merriami only summed across control plots at the newmoon.
   fun: prep_dataset
   args:
     name: dm_controls

--- a/inst/extdata/prefab_model_controls.yaml
+++ b/inst/extdata/prefab_model_controls.yaml
@@ -2,6 +2,7 @@ AutoArima:
   metadata:
     name: AutoArima
     descriptor: classic model, all species, focal species
+    text: AutoArima (Automatic Auto-Regressive Integrated Moving Average) is a flexible Auto-Regressive Integrated Moving Average (ARIMA) model fit to the data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model is selected and  fitted using the `auto.arima` and `forecast` functions in the **forecast** package [@Hyndman2013; @Hyndman2017] within the `AutoArima()` function. Generally, ARIMA models are defined according to three model structure parameters -- the number of autoregressive terms (p), the degree of differencing (d), and the order of the moving average (q), and are represented as ARIMA(p, d, q) [@Box1970]. While the `auto.arima` function allows for seasonal models, the seasonality is hard-coded to be on the same period as the sampling, which is not the case for the Portal rodent surveys. As a result, no seasonal models were evaluated. AutoArima is fit flexibly, such that the model parameters can vary from fit to fit.
   fun: auto.arima
   args: ~
   interpolate: no
@@ -18,6 +19,7 @@ ESSS:
   metadata:
     name: ESSS
     descriptor: classic model, all species, focal species, requires interpolation
+    text: ESSS (Exponential Smoothing State Space) is a flexible exponential smoothing state space model [@Hyndman2008] fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model is selected and fitted using the `ets` and `forecast` functions in the **forecast** package [@Hyndman2017] with the `allow.multiplicative.trend` argument set to `TRUE` within the `ESSS()` function. Models fit using `ets` implement what is known as the "innovations" approach to state space modeling, which assumes a single source of noise that is equivalent for the process and observation errors [@Hyndman2008]. In general, ESSS models are defined according to three model structure parameters -- error type, trend type, and seasonality type [@Hyndman2008]. Each of the parameters can be an N (none), A (additive), or M (multiplicative) state [@Hyndman2008]. However, because of the difference in period between seasonality and sampling of the Portal rodents combined with the hard-coded single period of the `ets` function, we could not include the seasonal components to the ESSS model. ESSS is fit flexibly, such that the model parameters can vary from fit to fit.
   fun: ets
   args: ~
   interpolate: yes
@@ -34,6 +36,7 @@ NaiveArima:
   metadata:
     name: NaiveArima
     descriptor: classic model, all species, focal species
+    text: NaiveArima (Naive Auto-Regressive Integrated Moving Average) is a fixed Auto-Regressive Integrated Moving Average (ARIMA) model of order (0,1,0) fit to the data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model is selected and fitted using the `Arima` and `forecast` functions in the **forecast** package [@Hyndman2013; @Hyndman2017] within the `NaiveArima()` function.
   fun: Arima
   args: 
     order: c(0, 1, 0)
@@ -51,6 +54,7 @@ nbGARCH:
   metadata:
     name: nbGARCH
     descriptor: classic model, all species, focal species, requires interpolation
+    text: nbGARCH (Negative Binomial Auto-Regressive Conditional Heteroskedasticity) is a generalized autoregressive conditional heteroskedasticity (GARCH) model with overdispersion (*i.e.*, a negative binomial response) fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model for each species and the community total is selected and fitted using the `tsglm` function in the **tscount** package [@Liboschik2017a] within the `nbGARCH()` function. GARCH models are generalized ARMA models and are defined according to their link function, response distribution, and two model structure parameters -- the number of autoregressive terms (p) and the order of the moving average (q), and are represented as GARCH(p, q) [@Liboschik2017a]. The nbGARCH model is fit using the log link and a negative binomial response (modeled as an over-dispersed Poisson), as well as with p = 1 (first-order autoregression) and q = 12 (approximately yearly moving average). The `tsglm` function in the **tscount** package [@Liboschik2017a] uses a (conditional) quasi-likelihood based approach to inference and models the overdispersion as an additional parameter in a two-step approach. This two-stage approach has only been minimally evaluated, although preliminary simulation-based studies are promising [@Liboschik2017b].
   fun: nbGARCH
   args: ~
   interpolate: yes
@@ -67,6 +71,7 @@ nbsGARCH:
   metadata:
     name: nbsGARCH
     descriptor: classic model, all species, focal species, requires interpolation
+    text: nbsGARCH (Negative Binomial Seasonal Auto-Regressive Conditional Heteroskedasticity) is a generalized autoregressive conditional heteroskedasticity (GARCH) model with overdispersion (*i.e.*, a negative binomial response) with seasonal predictors modeled using two Fourier series terms (sin and cos of the fraction of the year) fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model for each species and the community total is selected and fitted using the `tsglm` function in the **tscount** package [@Liboschik2017a] within the `nbsGARCH()` function. GARCH models are generalized ARMA models and are defined according to their link function, response distribution, and two model structure parameters -- the number of autoregressive terms (p) and the order of the moving average (q), and are represented as GARCH(p, q) [@Liboschik2017a]. The nbsGARCH model is fit using the log link and a negative binomial response (modeled as an over-dispersed Poisson), as well as with p = 1 (first-order autoregression) and q = 12 (approximately yearly moving average). The `tsglm` function in the **tscount** package [@Liboschik2017a] uses a (conditional) quasi-likelihood based approach to inference and models the overdispersion as an additional parameter in a two-step approach. This two-stage approach has only been minimally evaluated, although preliminary simulation-based studies are promising [@Liboschik2017b].    
   fun: nbsGARCH
   args: ~
   interpolate: yes
@@ -83,6 +88,7 @@ pevGARCH:
   metadata:
     name: pevGARCH
     descriptor: classic model, all species, focal species, requires interpolation
+    text: pevGARCH (Poisson Environmental Variable Auto-Regressive Conditional Heteroskedasticity) is a generalized autoregressive conditional heteroskedasticity (GARCH) model fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The response variable is Poisson, and a variety of environmental variables are considered as covariates. The model for each species is selected and fitted using the `tsglm` function in the **tscount** package [@Liboschik2017a] within the `pevGARCH()` function. GARCH models are generalized ARMA models and are defined according to their link function, response distribution, and two model structure parameters -- the number of autoregressive terms (p) and the order of the moving average (q), and are represented as GARCH(p, q) [@Liboschik2017a]. The pevGARCH model is fit using the log link and a Poisson response, as well as with p = 1 (first-order autoregression) and q = 12 (yearly moving average). The environmental variables potentially included in the model are min, mean, and max temperatures, precipitation, and NDVI.  The `tsglm` function in the **tscount** package [@Liboschik2017a] uses a (conditional) quasi-likelihood based approach to inference. This approach has only been minimally evaluated for models with covariates, although preliminary simulation-based studies are promising [@Liboschik2017b]. Each species is fit using the following (nonexhaustive) sets of the environmental covariates --  [1] max temp, mean temp, precipitation, NDVI; [2] max temp, min temp, precipitation, NDVI; [3] max temp, mean temp, min temp, precipitation; [4] precipitation, NDVI; [5] min temp, NDVI; [6] min temp; [7] max temp; [8] mean temp; [9] precipitation; [10] NDVI; and [11] -none- (intercept-only). The single best model of the 11 is selected based on AIC. 
   fun: pevGARCH
   datasets:
   - all
@@ -100,6 +106,7 @@ jags_RW:
   metadata:
     name: jags_RW
     descriptor: population model, focal species
+    text: jags_RW fits a hierarchical log-scale density random walk model with a Poisson observation process using the JAGS (Just Another Gibbs Sampler) infrastructure [@Plummer2003] fit to the  data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. Similar to the NaiveArima model, jags_RW has an ARIMA order of (0,1,0), but in jags_RW, it is the underlying density that takes a random walk on the log scale, whereas in NaiveArima, it is the raw counts that take a random walk on the observation scale. The jags_RW model is rather simple, but the `jags_RW()` function provides a starting template and underlying machinery for more articulated models using the JAGS infrastructure. There are two process parameters -- mu (the density of the species at the beginning of the time series) and tau (the precision (inverse variance) of the random walk, which is Gaussian on the log scale). The observation model has no additional parameters. The prior distributions for mu and tau are informed by the available data collected prior to the start of the data used in the time series. mu is normally distributed with a mean equal to the average log-scale density and a variance that is twice as large as the observed variance. Due to the presence of 0s in the data and the modeling on the log scale, an offset of `count + 0.1` is used prior to taking the log and then is removed after the reconversion (exponentiation) as `density - 0.1` (where `density` is on the same scale as `count`, but can take non-integer values).
   fun: jags_RW
   datasets: dm_controls
   args:
@@ -123,6 +130,7 @@ jags_logistic:
   metadata:
     name: jags_logistic
     descriptor: population model, focal species
+    text: jags_logistic fits a hierarchical log-scale density logistic growth model with a Poisson observation process using the JAGS (Just Another Gibbs Sampler) infrastructure [@Plummer2003] fit to the  data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. Building upon the jags_RW model, jags_logistic expands upon the "process model" underlying the Poisson observations. There are four process parameters -- mu (the density of the species at the beginning of the time series) and tau (the precision (inverse variance) of the random walk, which is Gaussian on the log scale) for the starting value and r (growth rate) and K (carrying capacity) of the dynamic population. The observation model has no additional parameters. The prior distributions for mu, tau, and K are informed by the available data collected prior to the start of the data used in the time series and r is set with a vague prior. mu is normally distributed with a mean equal to the average log-scale density and a variance that is twice as large as the observed variance. K is modeled on the log-scale with a prior mean and variance equal to the maximum of `past counts * 1.2`. r is given a normal prior with mean 0 and variance 0.1. Due to the presence of 0s in the data and the modeling on the log scale, an offset of `count + 0.1` is used prior to taking the log and then is removed after the reconversion (exponentiation) as `density - 0.1` (where `density` is on the same scale as `count`, but can take non-integer values). 
   fun: jags_logistic
   datasets: dm_controls
   args:

--- a/inst/extdata/prefab_model_controls.yaml
+++ b/inst/extdata/prefab_model_controls.yaml
@@ -2,8 +2,9 @@ AutoArima:
   metadata:
     name: AutoArima
     descriptor: classic model, all species, focal species
-  fun: AutoArima
+  fun: auto.arima
   args: ~
+  interpolate: no
   datasets:
   - all
   - controls
@@ -17,7 +18,7 @@ ESSS:
   metadata:
     name: ESSS
     descriptor: classic model, all species, focal species, requires interpolation
-  fun: ESSS
+  fun: ets
   args: ~
   interpolate: yes
   datasets:
@@ -33,8 +34,10 @@ NaiveArima:
   metadata:
     name: NaiveArima
     descriptor: classic model, all species, focal species
-  fun: NaiveArima
-  args: ~
+  fun: Arima
+  args: 
+    order: c(0, 1, 0)
+  interpolate: no
   datasets:
   - all
   - controls

--- a/vignettes/current_models.Rmd
+++ b/vignettes/current_models.Rmd
@@ -10,114 +10,42 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup, include=FALSE}
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>"
-)
+```{r setup, include = FALSE}
+
+  knitr::opts_chunk$set(collapse = TRUE,
+                        comment  = "#>")
+
+  fpath <- system.file("extdata", "prefab_model_controls.yaml", package = "portalcasting")
+  model_controls <- yaml::read_yaml(fpath)
+  model_names    <- names(model_controls)
+  nmodels        <- length(model_names)
+  nmodels_text   <- as.character(english::english(nmodels))
+
+
 ```
 
 ## Models
 
-We currently analyze and forecast rodent data at Portal using eight models: ESSS, AutoArima, NaiveArima, nbGARCH, nbsGARCH, pevGARCH, simplexEDM, and jags_RW [@PortalPredictions]. Each model has a function with its name (*e.g.*, `ESSS()`) which is called from an associated R script in the `models` subdirectory with its name (*e.g.*, `ESSS.R`)
-
-### ESSS
-
-ESSS (Exponential Smoothing State Space) is a flexible exponential smoothing state space model [@Hyndman2008] fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model is selected and fitted using the `ets` and `forecast` functions in the **forecast** package [@Hyndman2017] with the `allow.multiplicative.trend` argument set to `TRUE` within the `ESSS()` function. Models fit using `ets` implement what is known as the "innovations" approach to state space modeling, which assumes a single source of noise that is equivalent for the process and observation errors [@Hyndman2008].
-
-In general, ESSS models are defined according to three model structure parameters: error type, trend type, and seasonality type [@Hyndman2008]. Each of the parameters can be an N (none), A (additive), or M (multiplicative) state [@Hyndman2008]. However, because of the difference in period between seasonality and sampling of the Portal rodents combined with the hard-coded single period of the `ets` function, we could not include the seasonal components to the ESSS model. ESSS is fit flexibly, such that the model parameters can vary from fit to fit.
-
-### AutoArima
-
-AutoArima (Automatic Auto-Regressive Integrated Moving Average) is a flexible Auto-Regressive Integrated Moving Average (ARIMA) model fit to the data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model is selected and  fitted using the `auto.arima` and `forecast` functions in the **forecast** package [@Hyndman2013; @Hyndman2017] within the `AutoArima()` function.
-
-Generally, ARIMA models are defined according to three model structure parameters: the number of autoregressive terms (p), the degree of differencing (d), and the order of the moving average (q), and are represented as ARIMA(p, d, q) [@Box1970]. While the `auto.arima` function allows for seasonal models, the seasonality is hard-coded to be on the same period as the sampling, which is not the case for the Portal rodent surveys. As a result, no seasonal models were evaluated. AutoArima is fit flexibly, such that the model parameters can vary from fit to fit.
-
-### NaiveArima
-
-NaiveArima (Naive Auto-Regressive Integrated Moving Average) is a fixed Auto-Regressive Integrated Moving Average (ARIMA) model of order (0,1,0) fit to the data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model is selected and fitted using the `Arima` and `forecast` functions in the **forecast** package [@Hyndman2013; @Hyndman2017] within the `NaiveArima()` function.
+We currently analyze and forecast rodent data at Portal using `r nmodels_text` models: `r model_names` [@PortalPredictions]. Each model has a function with its name (*e.g.*, `ESSS()`) which is called from an associated R script in the `models` subdirectory with its name (*e.g.*, `ESSS.R`)
 
 
-### nbGARCH
+```{r echo = FALSE, results = "asis"}
 
-nbGARCH (Negative Binomial Auto-Regressive Conditional Heteroskedasticity) is a generalized autoregressive conditional heteroskedasticity (GARCH) model with overdispersion (*i.e.*, a negative binomial response) fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model for each species and the community total is selected and fitted using the `tsglm` function in the **tscount** package [@Liboschik2017a] within the `nbGARCH()` function.
+  template <- "### %s \n \n %s \n \n   \n"
 
-GARCH models are generalized ARMA models and are defined according to their link function, response distribution, and two model structure parameters: the number of autoregressive terms (p) and the order of the moving average (q), and are represented as GARCH(p, q) [@Liboschik2017a]. The nbGARCH model is fit using the log link and a negative binomial response (modeled as an over-dispersed Poisson), as well as with p = 1 (first-order autoregression)
-and q = 12 (approximately yearly moving average).
+  for (i in 1:nmodels) {
+    model_i_controls <- model_controls[[i]]
+    cat(sprintf(template, model_i_controls$metadata$name, model_i_controls$metadata$text))
+  }
+```
 
-The `tsglm` function in the **tscount** package [@Liboschik2017a] uses a (conditional) quasi-likelihood based approach to inference and models the overdispersion as an additional parameter in a two-step approach. This two-stage approach has only been minimally evaluated, although preliminary simulation-based studies are promising [@Liboschik2017b].    
-
-### nbsGARCH
-
-nbsGARCH (Negative Binomial Seasonal Auto-Regressive Conditional Heteroskedasticity) is a generalized autoregressive conditional heteroskedasticity (GARCH) model with overdispersion (*i.e.*, a negative binomial response) with seasonal predictors modeled using two Fourier series terms (sin and cos of the fraction of the year) fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The model for each species and the community total is selected and fitted using the `tsglm` function in the **tscount** package [@Liboschik2017a] within the `nbsGARCH()` function.
-
-GARCH models are generalized ARMA models and are defined according to their link function, response distribution, and two model structure parameters: the number of autoregressive terms (p) and the order of the moving average (q), and are represented as GARCH(p, q) [@Liboschik2017a]. The nbsGARCH model is fit using the log link and a negative binomial response (modeled as an over-dispersed Poisson), as well as with p = 1 (first-order autoregression) and q = 12 (approximately yearly moving average).
-
-The `tsglm` function in the **tscount** package [@Liboschik2017a] uses a (conditional) quasi-likelihood based approach to inference and models the overdispersion as an additional parameter in a two-step approach. This two-stage approach has only been minimally evaluated, although preliminary simulation-based studies are promising [@Liboschik2017b].    
-
-
-### pevGARCH
-
-pevGARCH (Poisson Environmental Variable Auto-Regressive Conditional Heteroskedasticity) is a generalized autoregressive conditional heteroskedasticity (GARCH) model fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The response variable is Poisson, and a variety of environmental variables are considered as covariates. The model for each species is selected and fitted using the `tsglm` function in the **tscount** package [@Liboschik2017a] within the `pevGARCH()` function.
-
-GARCH models are generalized ARMA models and are defined according to their link function, response distribution, and two model structure parameters: the number of autoregressive terms (p) and the order of the moving average (q), and are represented as GARCH(p, q) [@Liboschik2017a]. The pevGARCH model is fit using the log link and a Poisson response, as well as with p = 1 (first-order autoregression) and q = 12 (yearly moving average). The 
-environmental variables potentially included in the model are min, mean, and max temperatures, precipitation, and NDVI. 
-
-The `tsglm` function in the **tscount** package [@Liboschik2017a] uses a (conditional) quasi-likelihood based approach to inference. This approach has only been minimally evaluated for models with covariates, although preliminary simulation-based studies are promising [@Liboschik2017b].  
-
-Each species is fit using the following (nonexhaustive) sets of the environmental covariates:
-  * max temp, mean temp, precipitation, NDVI
-  * max temp, min temp, precipitation, NDVI
-  * max temp, mean temp, min temp, precipitation
-  * precipitation, NDVI
-  * min temp, NDVI
-  * min temp
-  * max temp
-  * mean temp
-  * precipitation 
-  * NDVI
-  * -none-
-  
-The final model is an intercept-only model. The single best model of the 11 is  selected based on AIC. 
-
-### jags_RW
-
-jags_RW fits a hierarchical log-scale density random walk model with a Poisson observation process using the JAGS (Just Another Gibbs Sampler) infrastructure [@Plummer2003] fit to the  data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. Similar to the NaiveArima model, jags_RW has an ARIMA order of (0,1,0), but in jags_RW, it is the underlying density that takes a random walk on the log scale, whereas in NaiveArima, it is the raw counts that take a random walk on the observation scale. The jags_RW model is rather simple, but the `jags_RW()` function provides a starting template and underlying machinery for more articulated models using the JAGS infrastructure. 
-
-There are two process parameters: mu (the density of the species at the beginning of the time series) and tau (the precision (inverse variance) of the random walk, which is Gaussian on the log scale). The observation model has no additional parameters. The prior distributions for mu and tau are informed by the available data collected prior to the start of the data used in the time series. mu is normally distributed with a mean equal to the average log-scale density and a variance that is twice as large as the observed variance. Due to the presence of 0s in the data and the modeling on the log scale, an offset of `count + 0.1` is used prior to taking the log and then is removed after the reconversion (exponentiation) as `density - 0.1` (where `density` is on the same scale as `count`, but can take non-integer values). 
-
-### jags_logistic
-
-jags_logistic fits a hierarchical log-scale density logistic growth model with a Poisson observation process using the JAGS (Just Another Gibbs Sampler) infrastructure [@Plummer2003] fit to the  data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. Building upon the jags_RW model, jags_logistic expands upon the "process model" underlying the Poisson observations. 
-
-There are four process parameters: mu (the density of the species at the beginning of the time series) and tau (the precision (inverse variance) of the random walk, which is Gaussian on the log scale) for the starting value and r (growth rate) and K (carrying capacity) of the dynamic population. The observation model has no additional parameters. 
-
-The prior distributions for mu, tau, and K are informed by the available data collected prior to the start of the data used in the time series and r is set with a vague prior. mu is normally distributed with a mean equal to the average log-scale density and a variance that is twice as large as the observed variance. K is modeled on the log-scale with a prior mean and variance equal to the maximum of the past counts * 1.2. r is given a normal prior with mean 0 and variance 0.1. Due to the presence of 0s in the data and the modeling on the log scale, an offset of `count + 0.1` is used prior to taking the log and then is removed after the reconversion (exponentiation) as `density - 0.1` (where `density` is on the same scale as `count`, but can take non-integer values). 
-
-
- 
 
 
 ### Ensemble
 
-In addition to the base models, we include a starting-point ensemble. In versions before v0.9.0, the ensemble was based on AIC weights, but in the shift to separating the interpolated from non-interpolated data in model fitting, we had to transfer to an unweighted average ensemble model. The ensemble mean is calculated as the mean of all model means and the ensemble variance is estimated as the sum of the mean of all model variances and the variance of the estimated mean, calculated using the unbiased estimate of sample variances.
-
-
-## Previously Used Models
-
-These models were previously part of the prefab model set, but have been retired for the time being due to broken source code.
-
-### simplexEDM
-
-simplexEDM (simplex projection using Empirical Dynamic Modeling) is a state-space reconstruction model adapted for forecasting and fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. The method uses time-delay embedding to reconstruct a state-space for the dynamics underlying a time series [@Packard1980, @Takens1981]. A forecast from a point in the state space is then computed as a weighted average of the trajectories of nearest neighbors of that point, a minimal algorithm known as "simplex projection" [@Sugihara1990].
-
-In applications to ecological time series, many of the parameters are set automatically, with the exception of the dimension of the time-delay embedding. Here, the embedding dimension ($E$) is selected as the value (between `1` and the `max_E` argument to `simplexEDM()`) that minimizes the mean absolute error over the in-sample portion of the data.
-
-### GPEDM
-
-GPEDM (Gaussian processes using Empirical Dynamic Modeling) is a state-space reconstruction model adapted for forecasting and fit to the interpolated data at the composite (full site and just control plots) spatial level and both the composite (community) and the articulated (species) ecological levels. . The method uses time-delay embedding to reconstruct a state-space for the dynamics underlying a time series [@Packard1980, @Takens1981]. The forecast function is approximate using Gaussian processes.
-
-As with `simplexEDM()`, many of the parameters are fit automatically, such as the length-scale, and variance parameters (see `rEDM::block_gp()` for details). One exception is the dimension of the time-delay embedding. Here, the embedding dimension ($E$) is selected as the value (between `1` and the `max_E` argument to `GPEDM()`) that minimizes the mean absolute error over the in-sample portion of the data.
+In addition to the base models, we include a starting-point ensemble. 
+Prior to v0.9.0, the ensemble was based on AIC weights, but in the shift to separating the interpolated from non-interpolated data in model fitting, we had to transfer to an unweighted average ensemble model. 
+The ensemble mean is calculated as the mean of all model means and the ensemble variance is estimated as the sum of the mean of all model variances and the variance of the estimated mean, calculated using the unbiased estimate of sample variances.
 
 
 ## References


### PR DESCRIPTION
pull text from the markdown vignette on the models into the model list, then loops the model list in the markdown doc
this locates the description in a place that is accessible to other content generation (e.g., the portal forecast website)