### PR TITLE
fixing jags model metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalcasting
 Title: Functions Used in Predicting Portal Rodent Dynamics
-Version: 0.46.0
+Version: 0.47.0
 Authors@R: c(
     person(c("Juniper", "L."), "Simonis",
       email = "juniper.simonis@weecology.org", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
 
+# [portalcasting 0.47.0](https://github.com/weecology/portalcasting/releases/tag/v0.47.0)
+*2023-02-21*
+
+### Patching error in cast metadata output for jags models
+* Multiple models had the jags_logistic_covariates name being used in the metadata output when that was not correct.
+
+
 # [portalcasting 0.46.0](https://github.com/weecology/portalcasting/releases/tag/v0.46.0)
 *2023-01-24*
 

--- a/R/models_jags.R
+++ b/R/models_jags.R
@@ -93,7 +93,7 @@ jags_logistic_competition <- function (main            = ".",
 
 
 
-  model_name     <- "jags_logistic_covariates"
+  model_name     <- "jags_logistic_competition"
 
   runjags.options(silent.jags    = control_runjags$silent_jags, 
                   silent.runjags = control_runjags$silent_jags)
@@ -269,7 +269,7 @@ jags_logistic_competition <- function (main            = ".",
   }
 
   metadata <- update_list(metadata,
-                          models           = "jags_logistic_covariates",
+                          models           = model_name,
                           datasets         = dataset,
                           dataset_controls = dataset_controls)
 
@@ -559,7 +559,7 @@ jags_logistic_competition_covariates <- function (main            = ".",
   }
 
   metadata <- update_list(metadata,
-                          models           = "jags_logistic_covariates",
+                          models           = model_name,
                           datasets         = dataset,
                           dataset_controls = dataset_controls)
 
@@ -844,7 +844,7 @@ jags_logistic_covariates <- function (main            = ".",
   }
 
   metadata <- update_list(metadata,
-                          models           = "jags_logistic_covariates",
+                          models           = model_name,
                           datasets         = dataset,
                           dataset_controls = dataset_controls)
 


### PR DESCRIPTION
multiple models had errounously been getting tagged as jags_logistic_covariates

generalizing to model_name in the code, where it should have been (was correct for the other jags models)